### PR TITLE
The gem does not include all the gems that requires once being installed

### DIFF
--- a/lib/opencage/version.rb
+++ b/lib/opencage/version.rb
@@ -1,3 +1,3 @@
 module OpenCage
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/opencage-geocoder.gemspec
+++ b/opencage-geocoder.gemspec
@@ -10,6 +10,6 @@ Gem::Specification.new do |s|
   s.description = "A client for the OpenCage Data geocoder API"
   s.authors     = ["Samuel Scully"]
   s.email       = 'dev@lokku.com'
-  s.files       = ["lib/opencage/geocoder.rb"]
+  s.files       = Dir['lib/**/*.{rb}']
   s.homepage    = 'https://github.com/lokku/ruby-opencage-geocoder'
 end


### PR DESCRIPTION
* This commit includes a fix to the issue that currently the gem does not include all the files required to work properly. Namely geocoder/location.rb

; issue lokku/ruby-opencage-geocoder#3